### PR TITLE
Add daily.dev Recruiter to Tech section

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ Contributions are welcome! Please read the [contribution guidelines](CONTRIBUTIN
 
 ## Tech
 
+- [daily.dev Recruiter](https://recruiter.daily.dev/) - Source and engage developers where they already spend time — on their personalized news feed
 - [Relocate.me](https://relocate.me/) - Verified relocation packages
 - [underpin](https://www.underpin.company/) - Tech jobs and job search advice from an actual recruiter
 - [Christian Tech Jobs](https://www.christiantechjobs.io/) - Tech jobs at Christian companies


### PR DESCRIPTION
[daily.dev Recruiter](https://recruiter.daily.dev/) lets companies source and engage developers directly where they spend time — on their personalized developer news feed. It connects recruiters with 1M+ developers through a double opt-in system, meaning developers actively choose to be discoverable.

Added to the Tech section, sorted alphabetically.