### PR TITLE
Add LeadJobs.dev to the job aggregator section

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Contributions are welcome! Please read the [contribution guidelines](CONTRIBUTIN
 
 - [findwork.dev](https://findwork.dev/)
 - [Levels.fyi](https://www.levels.fyi/jobs)
+- [LeadJobs.dev](https://leadjobs.dev) - Software Engineering Leadership Jobs Board (EM/Staff+ positions only, VP, Director, CTO)
 
 ### Clojure
 


### PR DESCRIPTION
Added LeadJobs.dev to aggregator section (LeadJobs.dev aggregates software engineering leadership jobs: EM/Staff+, VP, Director, CTO)