### PR TITLE
Add AI Dev Jobs to AI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Contributions are welcome! Please read the [contribution guidelines](CONTRIBUTIN
 
 ## Artificial Intelligence (AI)
 
+- [AI Dev Jobs](https://aidevboard.com) - The specialized job board for AI/ML developers. 5000+ curated roles with salary data and a REST API for agents.
 - [AI Jobs](https://www.moaijobs.com/) - AI Jobs in ML, Data Science, Engineering, and Research
 - [AI Jobs Dev](https://aijobs.dev) - Discover companies looking to hire AI, ML, Data Science & Big Data engineers and connect with them
 - [AI Jobs](https://aijobs.app) – Jobs in Artificial Intelligence (AI)

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Contributions are welcome! Please read the [contribution guidelines](CONTRIBUTIN
 
 ## Artificial Intelligence (AI)
 
-- [AI Dev Jobs](https://aidevboard.com) - The specialized job board for AI/ML developers. 5000+ curated roles with salary data and a REST API for agents.
+- [AI Dev Jobs](https://aidevboard.com) - AI/ML developer jobs with REST API and MCP server for agents
 - [AI Jobs](https://www.moaijobs.com/) - AI Jobs in ML, Data Science, Engineering, and Research
 - [AI Jobs Dev](https://aijobs.dev) - Discover companies looking to hire AI, ML, Data Science & Big Data engineers and connect with them
 - [AI Jobs](https://aijobs.app) – Jobs in Artificial Intelligence (AI)


### PR DESCRIPTION
Adding [AI Dev Jobs](https://aidevboard.com) to the Artificial Intelligence (AI) section.

AI/ML developer jobs with REST API and MCP server for agents.