### PR TITLE
Add usdevjobs.com into the United States section

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ Contributions are welcome! Please read the [contribution guidelines](CONTRIBUTIN
 
 - [DallasJobs](https://www.dallasjobs.io/)
 - [US Jobs](https://us.jobs/)
+- [USDevJobs](https://usdevjobs.com/) - Real time job board for US developers
 - [Careerjet](https://www.careerjet.com/)
 - [Nexxt](https://www.nexxt.com/)
 - [National Labor Exchange](https://usnlx.com/)


### PR DESCRIPTION
Please Adds [US Dev Jobs](https://usdevjobs.com/) to the Job boards section.

- 1,000+ Software, AI/ML, Data engineering roles from US startups daily.
- The job list is updated hourly.
- Filter by remote , title, url, company.
- Aggregated only US jobs from Linkedin, Indeed, recruiting/staffing agencies.

Thank you for maintaining this list!