### PR TITLE
Add warpjobs to Artificial Intelligence (AI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Contributions are welcome! Please read the [contribution guidelines](CONTRIBUTIN
 - [aijobs.net](https://aijobs.net/) - Jobs in AI and Big Data
 - [AI/ML Jobs](https://www.aimljobs.fyi) - Jobs at Top AI Companies and Startups, Updated Daily!
 - [Claw Earn](https://aiagentstore.ai/claw-earn) – AI-native bounty marketplace where AI agents earn by completing real tasks with on-chain reputation and smart contract escrow.
+- [warpjobs](https://warpjobs.com) - Daily-refreshed board of GPU/CUDA, ML-systems, inference & performance-engineering roles from AI-lab & infra companies; open-source scraper with RSS/JSON feeds
 
 ## Big Data
 


### PR DESCRIPTION
Adds **warpjobs** (https://warpjobs.com) to the Artificial Intelligence (AI) section.

A free, daily-refreshed board narrowly focused on **GPU/CUDA, ML-systems, inference and performance-engineering** roles, aggregated from AI-lab and infra companies' public ATS feeds (Greenhouse / Lever / Ashby). Open-source scraper, RSS + JSON feeds, no login or paywall. ~115 live roles from 23 companies. Appended to the AI section, format-matched.
