### PR TITLE
Add EmbeddedJobs to dedicated Embedded section

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Contributions are welcome! Please read the [contribution guidelines](CONTRIBUTIN
 - [Blockchain](#blockchain)
 - [Database](#database)
 - [Design](#design)
+- [Embedded](#embedded)
 - [DevOps](#devops)
 - [eCommerce](#ecommerce)
 - [Finance](#finance)
@@ -98,6 +99,10 @@ Contributions are welcome! Please read the [contribution guidelines](CONTRIBUTIN
 - [Open Source Design Jobs](https://opensourcedesign.net/jobs/)
 - [UX Jobs Board](https://www.uxjobsboard.com)
 - [UI & UX Designer Jobs](https://uiuxdesignerjobs.com/) | Hand-picked UI, UX & UXR Jobs
+
+## Embedded
+
+- [EmbeddedJobs](https://embedded.jobs) - Job board dedicated to embedded systems and firmware engineering roles
 
 ## DevOps
 


### PR DESCRIPTION
**Add EmbeddedJobs to dedicated Embedded section**

Adds [EmbeddedJobs](https://embedded.jobs) — a job board dedicated to embedded systems and firmware engineering roles — and creates a new top-level Embedded section for it.

Embedded systems engineering sits at the intersection of hardware and software, making it a distinct discipline from general programming language boards (Go, Rust, Python, etc.) and broad Tech boards. A dedicated section follows the same pattern as other specialized domains in the list (InfoSec, DevOps, Blockchain) and makes it easier for embedded engineers to find relevant opportunities at a glance.