### PR TITLE
Add freehire (open-source IT job aggregator)

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Contributions are welcome! Please read the [contribution guidelines](CONTRIBUTIN
 ### Aggregator
 
 - [findwork.dev](https://findwork.dev/)
+- [freehire](https://github.com/strelov1/freehire) - Open-source IT job aggregator for tech roles; normalizes, deduplicates and AI-enriches vacancies from many sources
 - [Levels.fyi](https://www.levels.fyi/jobs)
 - [LeadJobs.dev](https://leadjobs.dev) - Software Engineering Leadership Jobs Board (EM/Staff+ positions only, VP, Director, CTO)
 


### PR DESCRIPTION
Adds **freehire**, an open-source IT job aggregator (Go + PostgreSQL + Meilisearch). It normalizes vacancies from many ATS boards and public Telegram channels into one schema, deduplicates and AI-enriches them, and serves them over a filterable API.

Repo: https://github.com/strelov1/freehire