### PR TITLE
Add Global Remote Hub to Remote section

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ Contributions are welcome! Please read the [contribution guidelines](CONTRIBUTIN
 - [We Work Remotely](https://weworkremotely.com/)
 - [Werkington](https://www.werkington.com/)
 - [Remote Job Assistant](https://remotejobassistant.com/) - Remote jobs for non-technical workers including customer service, admin, and marketing roles.
+- [Global Remote Hub](https://globalremotehub.com/) - Remote & relocation jobs requiring German, French, or Spanish. For bilingual candidates.
 
 ### Aggregator
 


### PR DESCRIPTION
Adds Global Remote Hub to the Remote section — a free job board for bilingual candidates, listing remote and relocation roles that require German, French, or Spanish. Matches the existing entry format; one addition, no deletions.