### PR TITLE
Add SwissAIJob to Switzerland section

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,6 +506,7 @@ Contributions are welcome! Please read the [contribution guidelines](CONTRIBUTIN
 - [WeJob.ch](https://WeJob.ch/)
 - [Jobwinner](https://jobwinner.ch/en/)
 - [JobScout24](https://www.jobscout24.ch/en)
+- [SwissAIJob](https://swissaijob.ch/)
 
 ### Europe_Other
 


### PR DESCRIPTION
Adds [SwissAIJob](https://swissaijob.ch/) to the Switzerland section.

SwissAIJob is a job board aggregating AI/ML roles across Switzerland (academia, research institutes, and industry). It fills an AI/ML-specific niche alongside the existing Swiss general and dev-focused boards.