### PR TITLE
Add 4DayJob to Various

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ Contributions are welcome! Please read the [contribution guidelines](CONTRIBUTIN
 
 - [WorkInGreen.jobs](https://workingreen.jobs/) - Greentech related jobs
 - [ClimateTechList](https://www.climatetechlist.com/) - Comprehensive aggregator of 30,000+ job openings from 1,000 climate tech/clean energy companies' job boards, updated daily
+- [4DayJob](https://4dayjob.com/) - Job board for roles at companies running a 4-day work week, filterable by function and by country
 
 ## World
 


### PR DESCRIPTION
Adds **4DayJob** to the **Various** section.

**Why Various and not Remote:** the niche is the *schedule*, not the location — it lists roles at companies running a four-day work week, remote and on-site alike. That puts it beside WorkInGreen and ClimateTechList, which are also single-axis niche boards, rather than in Remote where it would be misfiled.

**Verified before submitting:**
- `https://4dayjob.com/` returns `200`.
- The description matches what the site actually does: function filters (Engineering, Design, Machine Learning, Research, Marketing, Sales, Finance) and country filters (USA, UK, Canada, Europe, Remote).
- One line added, existing `- [Name](url) - Description` style, no other files touched, no tracking parameters.

Disclosure: I run the board. Happy to reword or drop it if it isn't a fit for the list.
