### PR TITLE
Add ChainJobs to Blockchain section

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Contributions are welcome! Please read the [contribution guidelines](CONTRIBUTIN
 
 ## Blockchain
 
+- [ChainJobs](https://chainjobs.io) - 2,650+ live crypto, web3 & blockchain jobs re-scraped daily from companies official ATS boards, with employer-published salary data
 - [Crypto Jobs List](https://cryptojobslist.com/) - Crypto Jobs List is your #1 board to find and post crypto, bitcoin and blockchain jobs
 - [Cryptocurrency Jobs](https://cryptocurrencyjobs.co/) - The leading job board for blockchain and cryptocurrency jobs
 - [Blockchain Works](https://blockchain.works-hub.com/) - Discover **the best** Blockchain opportunities and articles with **Blockchain Works**


### PR DESCRIPTION
Adding **ChainJobs** (https://chainjobs.io) — a crypto/web3 job board with a different source model from the boards already listed:

- 2,650+ live roles across 120 companies, re-scraped **daily from companies' own official ATS boards** (Greenhouse/Lever/Ashby) — no reposts; roles auto-expire when closed at the source
- 470+ roles with **employer-published salary bands** (medians/percentiles at /crypto-salaries/, nothing estimated)
- Free to browse, no signup wall; every listing links to the employer's own application page
- Free JSON API + RSS feeds
- Non-technical roles (marketing/BD/community/ops) surfaced alongside engineering

Link verified live; entry follows the list's format and position conventions. Happy to adjust wording.
