### PR TITLE
Add GMI Jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Contributions are welcome! Please read the [contribution guidelines](CONTRIBUTIN
 
 - [ChainJobs](https://chainjobs.io) - 2,650+ live crypto, web3 & blockchain jobs re-scraped daily from companies official ATS boards, with employer-published salary data
 - [Crypto Jobs List](https://cryptojobslist.com/) - Crypto Jobs List is your #1 board to find and post crypto, bitcoin and blockchain jobs
+- [GMI Jobs](https://gmijobs.com/) - Crypto and Web3 jobs from 230+ companies, pulled from employers' official ATS boards, with salary and token-compensation data
 - [Cryptocurrency Jobs](https://cryptocurrencyjobs.co/) - The leading job board for blockchain and cryptocurrency jobs
 - [Blockchain Works](https://blockchain.works-hub.com/) - Discover **the best** Blockchain opportunities and articles with **Blockchain Works**
 - [Web3 Jobs](https://web3.career) - Looking for a web3 job? Web3 Jobs has 8,387+ web3 remote and offline jobs as Web3 Developer, Smart Contract Developer, Solidity Developer and much more. Switch your career to Web3 and join the future!


### PR DESCRIPTION
Adding [GMI Jobs](https://gmijobs.com) — crypto/Web3 job board with live roles from 230+ companies via employer ATS feeds, with salary and token-compensation data. Matches the existing entry format.