### PR TITLE
Add First Look Jobs to Artificial Intelligence (AI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Contributions are welcome! Please read the [contribution guidelines](CONTRIBUTIN
 - [AI/ML Jobs](https://www.aimljobs.fyi) - Jobs at Top AI Companies and Startups, Updated Daily!
 - [Claw Earn](https://aiagentstore.ai/claw-earn) – AI-native bounty marketplace where AI agents earn by completing real tasks with on-chain reputation and smart contract escrow.
 - [warpjobs](https://warpjobs.com) - Daily-refreshed board of GPU/CUDA, ML-systems, inference & performance-engineering roles from AI-lab & infra companies; open-source scraper with RSS/JSON feeds
+- [First Look Jobs](https://firstlookjobs.com) - Directory of remote AI training and domain-expert jobs from six referral programs (Mercor, micro1, Turing, Alignerr, Contra, Handshake AI). Advertised pay, weekly hours and country eligibility parsed per listing; hourly contracts, $6-$400/hr
 
 ## Big Data
 


### PR DESCRIPTION
Adds First Look Jobs to the Artificial Intelligence (AI) section.

A directory of remote jobs from six programmes that hire people to train and evaluate AI systems — Mercor, micro1, Turing, Alignerr, Contra and Handshake AI. Every live listing is re-scraped daily.

**What it adds that the section doesn't already have:** the boards listed here are mostly AI *engineering* roles. This covers the other side — the programmes paying domain experts (law, medicine, finance, engineering) to train and evaluate models. It also parses each programme's published country eligibility per listing, so you can filter to jobs actually open to applicants in your country rather than reading "Remote" and finding out after applying.

No signup, no paywall, no login. Every job links out to the programme's own application.

**Disclosure:** the site is monetised through the programmes' referral schemes and earns a commission if a listed programme hires someone. This is disclosed in the site footer on every page; noting it here since it's the business model.