### PR TITLE
Add SideQuest Board (freelance gig aggregator)

### DIFF
--- a/.github/workflows/awesome_bot.yml
+++ b/.github/workflows/awesome_bot.yml
@@ -33,4 +33,4 @@ jobs:
 
     # Runs a set of commands using the runners shell
     - name: Run awesome_bot linter
-      run: awesome_bot -w jobs.drupal.org,landing.jobs,www1.communitech.ca,ninjajobs.org,ScalaJobs.dev,javascriptjob.xyz,startup.jobs,pythonjob.xyz,remoteok.com README.md
+      run: awesome_bot -w jobs.drupal.org,landing.jobs,www1.communitech.ca,ninjajobs.org,ScalaJobs.dev,javascriptjob.xyz,startup.jobs,pythonjob.xyz,remoteok.com,androiddev.careers README.md

--- a/.github/workflows/awesome_bot.yml
+++ b/.github/workflows/awesome_bot.yml
@@ -33,4 +33,4 @@ jobs:
 
     # Runs a set of commands using the runners shell
     - name: Run awesome_bot linter
-      run: awesome_bot -w jobs.drupal.org,landing.jobs,www1.communitech.ca,ninjajobs.org,ScalaJobs.dev,reactjsjob.com README.md
+      run: awesome_bot -w jobs.drupal.org,landing.jobs,www1.communitech.ca,ninjajobs.org,ScalaJobs.dev,reactjsjob.com,javascriptjob.xyz README.md

--- a/.github/workflows/awesome_bot.yml
+++ b/.github/workflows/awesome_bot.yml
@@ -33,4 +33,4 @@ jobs:
 
     # Runs a set of commands using the runners shell
     - name: Run awesome_bot linter
-      run: awesome_bot -w jobs.drupal.org,landing.jobs,www1.communitech.ca,ninjajobs.org,ScalaJobs.dev,reactjsjob.com,javascriptjob.xyz README.md
+      run: awesome_bot -w jobs.drupal.org,landing.jobs,www1.communitech.ca,ninjajobs.org,ScalaJobs.dev,reactjsjob.com,javascriptjob.xyz,startup.jobs README.md

--- a/.github/workflows/awesome_bot.yml
+++ b/.github/workflows/awesome_bot.yml
@@ -33,4 +33,4 @@ jobs:
 
     # Runs a set of commands using the runners shell
     - name: Run awesome_bot linter
-      run: awesome_bot -w jobs.drupal.org,landing.jobs,www1.communitech.ca,ninjajobs.org,ScalaJobs.dev README.md
+      run: awesome_bot -w jobs.drupal.org,landing.jobs,www1.communitech.ca,ninjajobs.org,ScalaJobs.dev,reactjsjob.com README.md

--- a/.github/workflows/awesome_bot.yml
+++ b/.github/workflows/awesome_bot.yml
@@ -33,4 +33,4 @@ jobs:
 
     # Runs a set of commands using the runners shell
     - name: Run awesome_bot linter
-      run: awesome_bot -w jobs.drupal.org,landing.jobs,www1.communitech.ca,ninjajobs.org,ScalaJobs.dev,reactjsjob.com,javascriptjob.xyz,startup.jobs,pythonjob.xyz,remoteok.com README.md
+      run: awesome_bot -w jobs.drupal.org,landing.jobs,www1.communitech.ca,ninjajobs.org,ScalaJobs.dev,javascriptjob.xyz,startup.jobs,pythonjob.xyz,remoteok.com README.md

--- a/.github/workflows/awesome_bot.yml
+++ b/.github/workflows/awesome_bot.yml
@@ -33,4 +33,4 @@ jobs:
 
     # Runs a set of commands using the runners shell
     - name: Run awesome_bot linter
-      run: awesome_bot -w jobs.drupal.org,landing.jobs,www1.communitech.ca,ninjajobs.org,ScalaJobs.dev,reactjsjob.com,javascriptjob.xyz,startup.jobs README.md
+      run: awesome_bot -w jobs.drupal.org,landing.jobs,www1.communitech.ca,ninjajobs.org,ScalaJobs.dev,reactjsjob.com,javascriptjob.xyz,startup.jobs,pythonjob.xyz,remoteok..com README.md

--- a/.github/workflows/awesome_bot.yml
+++ b/.github/workflows/awesome_bot.yml
@@ -33,4 +33,4 @@ jobs:
 
     # Runs a set of commands using the runners shell
     - name: Run awesome_bot linter
-      run: awesome_bot -w jobs.drupal.org,landing.jobs,www1.communitech.ca,ninjajobs.org,ScalaJobs.dev,reactjsjob.com,javascriptjob.xyz,startup.jobs,pythonjob.xyz,remoteok..com README.md
+      run: awesome_bot -w jobs.drupal.org,landing.jobs,www1.communitech.ca,ninjajobs.org,ScalaJobs.dev,reactjsjob.com,javascriptjob.xyz,startup.jobs,pythonjob.xyz,remoteok.com README.md

--- a/.github/workflows/awesome_bot.yml
+++ b/.github/workflows/awesome_bot.yml
@@ -33,4 +33,4 @@ jobs:
 
     # Runs a set of commands using the runners shell
     - name: Run awesome_bot linter
-      run: awesome_bot -w jobs.drupal.org,landing.jobs,www1.communitech.ca,ninjajobs.org,ScalaJobs.dev,javascriptjob.xyz,startup.jobs,pythonjob.xyz,remoteok.com,androiddev.careers,rubyonremote.com,rustjobs.dev,scalajobs.com README.md
+      run: awesome_bot -w jobs.drupal.org,landing.jobs,www1.communitech.ca,startup.jobs,remoteok.com,rubyonremote.com,rustjobs.dev,scalajobs.com README.md

--- a/.github/workflows/awesome_bot.yml
+++ b/.github/workflows/awesome_bot.yml
@@ -33,4 +33,4 @@ jobs:
 
     # Runs a set of commands using the runners shell
     - name: Run awesome_bot linter
-      run: awesome_bot -w jobs.drupal.org,landing.jobs,www1.communitech.ca,ninjajobs.org,ScalaJobs.dev,javascriptjob.xyz,startup.jobs,pythonjob.xyz,remoteok.com,androiddev.careers README.md
+      run: awesome_bot -w jobs.drupal.org,landing.jobs,www1.communitech.ca,ninjajobs.org,ScalaJobs.dev,javascriptjob.xyz,startup.jobs,pythonjob.xyz,remoteok.com,androiddev.careers,rubyonremote.com,rustjobs.dev,scalajobs.com README.md

--- a/.github/workflows/awesome_bot.yml
+++ b/.github/workflows/awesome_bot.yml
@@ -33,4 +33,4 @@ jobs:
 
     # Runs a set of commands using the runners shell
     - name: Run awesome_bot linter
-      run: awesome_bot -w jobs.drupal.org,landing.jobs,www1.communitech.ca,startup.jobs,remoteok.com,rubyonremote.com,rustjobs.dev,scalajobs.com README.md
+      run: awesome_bot -w jobs.drupal.org,landing.jobs,www1.communitech.ca,startup.jobs,remoteok.com,rubyonremote.com,rustjobs.dev,scalajobs.com,www.levels.fyi,dailyremote.com,workinbiotech.com,swissdevjobs.ch README.md

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ A curated list of awesome niche job boards.
 * [Wait, What Do You Do?](https://waitwhatdoyoudo.com/) - Jobs in data science, analytics, and engineering where you know what you'll really be doing
 * [Data Science Jobs Canada](https://www.datasciencejobscanada.com/) - Jobs in Data Science, Data Engineering, Data Analysis, AI, and Machine Learning
 * [AiJobsTracker](https://www.aijobstracker.com/) - live aggregator of 300+ AI-first companies's job boards, updated daily.
+* [DataScienceJobs](http://datasciencejobs.com/) - Discover the latest and greatest data science jobs.
 
 ## Blockchain
 

--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ A curated list of awesome niche job boards.
 
 ### Mobile
 
-* [androiddev.careers](https://androiddev.careers/) – Job board for Android developers
 * [React Native Jobs](https://reactnative-jobs.com) — A dedicated job board for React Native developers and companies.
+* [androiddev.careers](https://androiddev.careers/) – Job board for Android developers
 
 ### Perl
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ A curated list of awesome niche job boards.
 
 ## eCommerce
 
-* [eComPortal] (https://www.ecomportal.co/) - Job board for the eCommerce Industry. Lots of front-end & full-stack developer job opportunities. Remote & Salary available. 
+* [eComPortal](https://www.ecomportal.co/) - Job board for the eCommerce Industry. Lots of front-end & full-stack developer job opportunities. Remote & Salary available. 
 
 ## Finance
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ A curated list of awesome niche job boards.
 * [Coroflot](https://www.coroflot.com/design-jobs)
 * [IXDA](https://www.ixda.org/jobs/)
 * [Jobs for Designers](https://dribbble.com/jobs)
-* [Krop](https://www.krop.com/creative-jobs/)
 * [Open Source Design Jobs](https://opensourcedesign.net/jobs/)
 * [UX Jobs Board](https://www.uxjobsboard.com)
 * [UI & UX Designer Jobs](https://uiuxdesignerjobs.com/) | Hand-picked UI, UX & UXR Jobs
@@ -144,7 +143,6 @@ A curated list of awesome niche job boards.
 * [Drupal Jobs](https://jobs.drupal.org/)
 * [jobs.wordpress.net](https://jobs.wordpress.net/)
 * [LaraJobs](https://larajobs.com/)
-* [WPhired](https://www.wphired.com/) - WordPress Jobs
 * [Jobbsy](https://jobbsy.dev) - Symfony Jobs
 
 ### Python

--- a/README.md
+++ b/README.md
@@ -213,6 +213,9 @@ A curated list of awesome niche job boards.
 * [Next Level Jobs EU](https://nextleveljobs.eu/?utm_source=github&utm_medium=referral&utm_campaign=tramcar-awesome-job-boards) - €100k+ Software Engineering Jobs 🇪🇺
 * [Work In Tech](https://www1.communitech.ca/jobs) - Find your next role at Canada's fastest-growing tech companies
 
+## Africa
+* [Hired Jobs](https://www.hired.co.ke) - Jobs in all available job categories. Both remote and onsite jobs.
+
 ### United Kingdom
 
 * [IT Jobs Watch](https://www.itjobswatch.co.uk/) - Includes free technology skill set trends, salary/contractor rate benchmarking, and real-time job vacancy statistics

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ A curated list of awesome niche job boards.
 * [Cryptocurrency Jobs](https://cryptocurrencyjobs.co/) - The leading job board for blockchain and cryptocurrency jobs
 * [Blockchain Works](https://blockchain.works-hub.com/) - Discover **the best** Blockchain opportunities and articles with **Blockchain Works**
 * [Web3 Jobs](https://web3.career) - Looking for a web3 job? Web3 Jobs has 8,387+ web3 remote and offline jobs as Web3 Developer, Smart Contract Developer, Solidity Developer and much more. Switch your career to Web3 and join the future!
-* [Remote Web3 Jobs](https://remote3.co/) - A remote web3 job board onboarding people to web3 sharing web3 content, guides & tutorials for free
+* [Remote Web3 Jobs](https://www.remote3.co/) - A remote web3 job board onboarding people to web3 sharing web3 content, guides & tutorials for free
 * [My Web3 Jobs](https://myweb3jobs.com) - Find or Post web3 Jobs Today! New web3 Blockchain, Developer, and Designer Jobs handpicked every week
 * [Woody3](https://www.woodyjobs.com) - Find your dream non-tech job in Web3
 * [Jobs In Blockchain](https://jobsinblockchain.com) - Discover latest Blockchain, Web3, Smart Contracts, Defi, NFT, Cryptocurrency related jobs

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A curated list of awesome niche job boards.
 - [Artificial Intelligence (AI)](#artificial-intelligence-ai)
 - [Big Data](#big-data)
 - [Blockchain](#blockchain)
+- [Database](#database)
 - [Design](#design)
 - [DevOps](#devops)
 - [eCommerce](#ecommerce)
@@ -53,6 +54,10 @@ A curated list of awesome niche job boards.
 
 * [CNCF Job Board](https://jobs.cncf.io/) - Kubernetes and cloud native jobs
 * [Cloud Careers Hub](https://cloudcareershub.com/) - Job board for all roles related to Cloud Computing & Artificial Intelligence 
+
+## Database
+
+* [Webscale Jobs](https://www.webscale.work/) - Find a career working with MongoDB
 
 ## Design
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ A curated list of awesome niche job boards.
 ### Mobile
 
 * [androiddev.careers](https://androiddev.careers/) – Job board for Android developers
+* [React Native Jobs](https://reactnative-jobs.com) — A dedicated job board for React Native developers and companies.
 
 ### Perl
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ A curated list of awesome niche job boards.
 
 ## eCommerce
 
-* [eComPortal] (https://ecomportal.co/) - Job board for the eCommerce Industry. Lots of front-end & full-stack developer job opportunities. Remote & Salary available. 
+* [eComPortal] (https://www.ecomportal.co/) - Job board for the eCommerce Industry. Lots of front-end & full-stack developer job opportunities. Remote & Salary available. 
 
 ## Finance
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ A curated list of awesome niche job boards.
 
 ## Remote
 
+* [100% Work From Anywhere jobs](https://www.realworkfromanywhere.com/) - Fully remote jobs to live and work from anywhere
 * [We Work Remotely](https://weworkremotely.com/)
 * [DailyRemote](https://dailyremote.com/)
 * [Werkington](https://www.werkington.com/)

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ A curated list of awesome niche job boards.
 * [Wait, What Do You Do?](https://waitwhatdoyoudo.com/) - Jobs in data science, analytics, and engineering where you know what you'll really be doing
 * [Data Science Jobs Canada](https://www.datasciencejobscanada.com/) - Jobs in Data Science, Data Engineering, Data Analysis, AI, and Machine Learning
 * [DataScienceJobs](https://datasciencejobs.com/) - Discover the latest and greatest data science jobs.
+* [AiJobsTracker](https://www.aijobs.18offers.com/) | live aggregator of 400+ AI-first companies's job boards, updated daily.
+
 
 ## Blockchain
 
@@ -216,4 +218,4 @@ A curated list of awesome niche job boards.
 ## Various
 * [WorkInGreen.jobs](https://workingreen.jobs/) - Greentech related jobs
 * [Privacy-First Jobs](https://privacyfirstjobs.com/) – Jobs in privacy-first companies and organisations.
-* [ClimateTechList](https://www.climatetechlist.com/) - climate tech / green energy jobs for software engineers, PMs, & other tech professionals, live aggregator of 600 companies' job boards, updated daily.
+* [ClimateTechList](https://www.climatetechlist.com/) | comprehensive aggregator of 30,000+ job openings from 1,000 climate tech/clean energy companies' job boards, updated daily.

--- a/README.md
+++ b/README.md
@@ -213,6 +213,10 @@ A curated list of awesome niche job boards.
 * [Next Level Jobs EU](https://nextleveljobs.eu/?utm_source=github&utm_medium=referral&utm_campaign=tramcar-awesome-job-boards) - €100k+ Software Engineering Jobs 🇪🇺
 * [Work In Tech](https://www1.communitech.ca/jobs) - Find your next role at Canada's fastest-growing tech companies
 
+### Latin America
+
+* [Findjobit](https://findjobit.com/jobs)
+
 ### United Kingdom
 
 * [IT Jobs Watch](https://www.itjobswatch.co.uk/) - Includes free technology skill set trends, salary/contractor rate benchmarking, and real-time job vacancy statistics

--- a/README.md
+++ b/README.md
@@ -215,5 +215,4 @@ A curated list of awesome niche job boards.
 
 ## Various
 * [WorkInGreen.jobs](https://workingreen.jobs/) - Greentech related jobs
-* [Privacy-First Jobs](https://privacyfirstjobs.com/) – Jobs in privacy-first companies and organisations.
 * [ClimateTechList](https://www.climatetechlist.com/) - climate tech / green energy jobs for software engineers, PMs, & other tech professionals, live aggregator of 600 companies' job boards, updated daily.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ A curated list of awesome niche job boards.
 * [AI Jobs](https://aijobs.app) – Jobs in Artificial Intelligence (AI)
 * [ai-jobs.net](https://ai-jobs.net/) - Jobs in AI and Big Data
 * [thrive](https://thriveml.com) - Jobs at Top AI Companies and Startups
+* [Best AI Jobs](https://bestaijobs.com) - Best AI Jobs from 100+ AI Startups
 
 ## Big Data
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A curated list of awesome niche job boards.
 - [Open Source](#opensource)
 - [Programming](#programming)
 - [Remote](#remote)
-- [Quantum Computing)(#quantum-computing)
+- [Quantum Computing](#quantum-computing)
 - [Tech](#tech)
 - [Writing](#writing)
 - [Various](#various)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A curated list of awesome niche job boards.
 
 * [AI Jobs Dev](https://aijobs.dev) - Discover companies looking to hire AI, ML, Data Science & Big Data engineers and connect with them
 * [AI Jobs](https://aijobs.app) – Jobs in Artificial Intelligence (AI)
-* [ai-jobs.net](https://ai-jobs.net/) - Jobs in AI and Big Data
+* [aijobs.net](https://aijobs.net/) - Jobs in AI and Big Data
 * [AI/ML Jobs](https://www.aimljobs.fyi) - Jobs at Top AI Companies and Startups, Updated Daily!
 * [AI Jobs Board](https://aijobsboard.net) - Jobs in AI/ML
 
@@ -93,7 +93,7 @@ A curated list of awesome niche job boards.
 ## InfoSec
 
 * [NinjaJobs](https://ninjajobs.org/) - A community-run job platform developed by InfoSec professionals
-* [infosec-jobs.com](https://infosec-jobs.com/) - A fresh and lean InfoSec jobs board
+* [isecjobs.com](https://isecjobs.com/) - A fresh and lean InfoSec jobs board
 
 ## Programming
 
@@ -158,13 +158,9 @@ A curated list of awesome niche job boards.
 
 * [Rust Jobs](https://www.rustjobs.com) - A job board dedicated to the Rust programming language
 * [Rust Jobs](https://rustjobs.dev) - The go-to hiring platform for Rust engineering talent
-* [Rust Jobs - Remote and OnSite](https://rustjob.xyz)
 
 ### Scala
 * [Scala Jobs](https://scalajobs.com)
-
-### Java
-* [JavaProHire](https://javaprohire.com/) - A job board crafted with a laser focus on Java developers
 
 ### TypeScript
 * [TypeScript Jobs](https://typescriptjobs.dev)
@@ -212,7 +208,6 @@ A curated list of awesome niche job boards.
 * [Landing.jobs](https://landing.jobs/?utm_source=github&utm_medium=referral&utm_content=whfio&utm_campaign=post)
 * [GermanTech Jobs](https://germantechjobs.de/) - Dedicated Tech Job Board for Germany
 * [SwissDev Jobs](https://swissdevjobs.ch/) - Jobs for Software Developers from the EU that want to work in Switzerland
-* [WeJob.ch](https://WeJob.ch/?utm_source=github&utm_medium=referral&utm_campaign=tramcar-awesome-job-boards) - Developers and IT Jobs in Switzerland 🇨🇭
 
 ### United Kingdom
 
@@ -221,7 +216,6 @@ A curated list of awesome niche job boards.
 ## Writing
 
 * [WorkingInContent.com](https://workingincontent.com/) - Jobs in Content Strategy, Content Design, UX Writing and more
-* [Write the Docs Job Board](https://jobs.writethedocs.org/) - Jobs for people who care about documentation
 
 ## Various
 * [WorkInGreen.jobs](https://workingreen.jobs/) - Greentech related jobs

--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ A curated list of awesome niche job boards.
 
 * [Relocate.me](https://relocate.me/) - Verified relocation packages
 * [Christian Tech Jobs](https://www.christiantechjobs.io/) - Tech jobs at Christian companies
+* [EmbeddedJobs](https://embedded.jobs) - A niche job board exclusively for Embedded Systems engineers and developers.
 
 ### Africa
 * [Hired Jobs](https://www.hired.co.ke) - Jobs in all available job categories. Both remote and onsite jobs.

--- a/README.md
+++ b/README.md
@@ -105,10 +105,6 @@ A curated list of awesome niche job boards.
 
 * [ClojureJobboard.com](https://ClojureJobboard.com/)- Clojure jobs, also got a remote section
 
-### Full-Stack
-
-* [Full-Stack Developer Jobs](https://fullstackjob.com/) - Job board for Full-Stack Developers
-
 ### Functional
 
 * [FunctionalJobs.dev](https://functionaljobs.dev/) - Highly active job board for functional programming enthusiasts
@@ -197,7 +193,6 @@ A curated list of awesome niche job boards.
 
 ## Tech
 
-* [Free & Open Source Jobs](https://www.fossjobs.net/)
 * [Relocate.me](https://relocate.me/) - Verified relocation packages
 * [underpin](https://www.underpin.company/) - Tech jobs and job search advice from an actual recruiter
 * [Fossfox](https://fossfox.com/) - Opportunities to work with companies that embrace open-source

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A curated list of awesome niche job boards.
 
 * [AI Jobs](https://aijobs.app) – Jobs in Artificial Intelligence (AI)
 * [ai-jobs.net](https://ai-jobs.net/) - Jobs in AI and Big Data
-* [AI/ML Jobs](https://aimljobs.fyi) - Jobs at Top AI Companies and Startups
+* [AI/ML Jobs](https://aimljobs.fyi) - Jobs at Top AI Companies and Startups, Updated Daily!
 * [AI Jobs Board](https://aijobsboard.net) - Jobs in AI/ML
 
 ## Big Data

--- a/README.md
+++ b/README.md
@@ -210,7 +210,8 @@ A curated list of awesome niche job boards.
 * [GermanTech Jobs](https://germantechjobs.de/) - Dedicated Tech Job Board for Germany
 * [SwissDev Jobs](https://swissdevjobs.ch/) - Jobs for Software Developers from the EU that want to work in Switzerland
 * [DanishTech.co](https://danishtech.co/?utm_source=github&utm_medium=referral&utm_campaign=tramcar-awesome-job-boards) - Dedicated Tech Job Board for Denmark 🇩🇰
-* [Next Level Jobs EU](https://nextleveljobs.eu/?utm_source=github&utm_medium=referral&utm_campaign=tramcar-awesome-job-boards) -  €100k+ Software Engineering Jobs 🇪🇺
+* [Next Level Jobs EU](https://nextleveljobs.eu/?utm_source=github&utm_medium=referral&utm_campaign=tramcar-awesome-job-boards) - €100k+ Software Engineering Jobs 🇪🇺
+* [Work In Tech](https://www1.communitech.ca/jobs) - Find your next role at Canada's fastest-growing tech companies
 
 ### United Kingdom
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ A curated list of awesome niche job boards.
 * [Data Yoshi](https://www.datayoshi.com/) - Jobs in Data Science, Analytics, AI and Machine Learning
 * [Deep Learning Jobs](https://www.deeplearningjobs.com/) - Jobs in Deep Learning
 * [Wait, What Do You Do?](https://waitwhatdoyoudo.com/) - Jobs in data science, analytics, and engineering where you know what you'll really be doing
+* [Data Science Jobs Canada](https://www.datasciencejobscanada.com/) - Jobs in Data Science, Data Engineering, Data Analysis, AI, and Machine Learning
 
 ## Blockchain
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ A curated list of awesome niche job boards.
 * [Remote Web3 Jobs](https://remote3.co) - A remote web3 job board onboarding people to web3 sharing web3 content, guides & tutorials for free.
 * [My Web3 Jobs](https://myweb3jobs.com) - Find or Post web3 Jobs Today! New web3 Blockchain, Developer, and Designer Jobs handpicked every week.
 * [Woody3](https://www.woodyjobs.com) - Find your dream non-tech job in Web3
-* [Jobs In Blockchains](https://jobsinblockchain.com) - Discover latest Blockchain, Web3, Smart Contracts, Defi, NFT, Cryptocurrency related jobs.
+* [Jobs In Blockchain](https://jobsinblockchain.com) - Discover latest Blockchain, Web3, Smart Contracts, Defi, NFT, Cryptocurrency related jobs.
 
 ## Cloud
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ A curated list of awesome niche job boards.
 * [aijobs.net](https://aijobs.net/) - Jobs in AI and Big Data
 * [AI/ML Jobs](https://www.aimljobs.fyi) - Jobs at Top AI Companies and Startups, Updated Daily!
 * [AI Jobster](https://aijobster.work/) - Jobs from leading AI companies, across all group.
+* [ExploreJobs.ai](https://explorejobs.ai) - Find engineering, product, and research roles at the top AI startups.
 
 ## Big Data
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ A curated list of awesome niche job boards.
 * [findwork.dev](https://findwork.dev/)
 * [Levels.fyi](https://www.levels.fyi/jobs)
 * [Dev Employ](https://devemploy.com/) - Hand-picked developer jobs
+* [androiddev.careers](http://androiddev.careers/) – Job board for Android developers
 
 ### Clojure
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ A curated list of awesome niche job boards.
 * [findwork.dev](https://findwork.dev/)
 * [Levels.fyi](https://www.levels.fyi/jobs)
 * [Mecruit Job Board](https://www.mecruit.com/)
+* [GrepJob.com](https://grepjob.com/) - Software Engineering jobs scraped from established company career pages
 
 ### Clojure
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ A curated list of awesome niche job boards.
 * [Wait, What Do You Do?](https://waitwhatdoyoudo.com/) - Jobs in data science, analytics, and engineering where you know what you'll really be doing
 * [Data Science Jobs Canada](https://www.datasciencejobscanada.com/) - Jobs in Data Science, Data Engineering, Data Analysis, AI, and Machine Learning
 * [DataScienceJobs](https://datasciencejobs.com/) - Discover the latest and greatest data science jobs
-* [AiJobsTracker](https://aijobs.18offers.com/) | live aggregator of 400+ AI-first companies's job boards, updated daily.
+* [AiJobsTracker](https://aijobs.18offers.com/) - Live aggregator of 400+ AI-first companies's job boards, updated daily
 
 ## Blockchain
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ A curated list of awesome niche job boards.
 
 ### Functional
 
-* [Functional Jobs](https://www.functionaljobs.com/) - Job board for functional programmers
+* [FunctionalJobs.dev](https://functionaljobs.dev/) - Highly active job board for functional programming enthusiasts
 * [Functional Works](https://functional.works-hub.com/) - Discover local and remote functional programming opportunities
 
 ### Go

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ A curated list of awesome niche job boards.
 * [Open Source Design Jobs](https://opensourcedesign.net/jobs/)
 * [UX Jobs Board](https://www.uxjobsboard.com)
 * [UI & UX Designer Jobs](https://uiuxdesignerjobs.com/) | Hand-picked UI, UX & UXR Jobs
+* [UI/UX Jobs Board](https://uiuxjobsboard.com/)
 
 ## DevOps
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ A curated list of awesome niche job boards.
 * [Remote Web3 Jobs](https://remote3.co) - A remote web3 job board onboarding people to web3 sharing web3 content, guides & tutorials for free.
 * [My Web3 Jobs](https://myweb3jobs.com) - Find or Post web3 Jobs Today! New web3 Blockchain, Developer, and Designer Jobs handpicked every week.
 * [Woody3](https://www.woodyjobs.com) - Find your dream non-tech job in Web3
-* [Jobs In Blockchains](https://jobsinblockchains.com) - Discover latest Blockchain, Web3, Smart Contracts, Defi, NFT, Cryptocurrency related jobs.
+* [Jobs In Blockchains](https://jobsinblockchain.com) - Discover latest Blockchain, Web3, Smart Contracts, Defi, NFT, Cryptocurrency related jobs.
 
 ## Cloud
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ A curated list of awesome niche job boards.
 * [Wait, What Do You Do?](https://waitwhatdoyoudo.com/) - Jobs in data science, analytics, and engineering where you know what you'll really be doing
 * [Data Science Jobs Canada](https://www.datasciencejobscanada.com/) - Jobs in Data Science, Data Engineering, Data Analysis, AI, and Machine Learning
 * [AiJobsTracker](https://www.aijobstracker.com/) - live aggregator of 300+ AI-first companies's job boards, updated daily.
-* [DataScienceJobs](http://datasciencejobs.com/) - Discover the latest and greatest data science jobs.
+* [DataScienceJobs](https://datasciencejobs.com/) - Discover the latest and greatest data science jobs.
 
 ## Blockchain
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ A curated list of awesome niche job boards.
 * [Deep Learning Jobs](https://www.deeplearningjobs.com/) - Jobs in Deep Learning
 * [Wait, What Do You Do?](https://waitwhatdoyoudo.com/) - Jobs in data science, analytics, and engineering where you know what you'll really be doing
 * [Data Science Jobs Canada](https://www.datasciencejobscanada.com/) - Jobs in Data Science, Data Engineering, Data Analysis, AI, and Machine Learning
+* [AiJobsTracker](https://www.aijobstracker.com/) - live aggregator of 300+ AI-first companies's job boards, updated daily.
 
 ## Blockchain
 
@@ -223,5 +224,6 @@ A curated list of awesome niche job boards.
 * [Write the Docs Job Board](https://jobs.writethedocs.org/) - Jobs for people who care about documentation
 
 ## Various
+* [ClimateTechList](https://www.climatetechlist.com/) - climate tech / green energy jobs for software engineers, PMs, & other tech professionals, live aggregator of 600 companies' job boards, updated daily
 * [WorkInGreen.jobs](https://workingreen.jobs/) - Greentech related jobs
 * [Privacy-First Jobs](https://privacyfirstjobs.com/) – Jobs in privacy-first companies and organisations.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ A curated list of awesome niche job boards.
 - [Gaming](#gaming)
 - [Growth Hacking](#growth-hacking)
 - [InfoSec](#infosec)
-- [Machine Learning](#machine-learning)
 - [Programming](#programming)
 - [Remote](#remote)
 - [Tech](#tech)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ A curated list of awesome niche job boards.
 - [Artificial Intelligence (AI)](#artificial-intelligence-ai)
 - [Big Data](#big-data)
 - [Blockchain](#blockchain)
-- [Customer Support](#customer-support)
 - [Design](#design)
 - [DevOps](#devops)
 - [eCommerce](#ecommerce)

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ A curated list of awesome niche job boards.
 * [AI Jobs](https://aijobs.app) – Jobs in Artificial Intelligence (AI)
 * [aijobs.net](https://aijobs.net/) - Jobs in AI and Big Data
 * [AI/ML Jobs](https://www.aimljobs.fyi) - Jobs at Top AI Companies and Startups, Updated Daily!
+* [AI Jobster](https://aijobster.work/) - Jobs from leading AI companies, across all group.
 
 ## Big Data
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ A curated list of awesome niche job boards.
 ## Blockchain
 
 * [Crypto Jobs List](https://cryptojobslist.com/) - Crypto Jobs List is your #1 board to find and post crypto, bitcoin and blockchain jobs
-* [Crypto Jobs](https://www.cryptojobs.co/) - CryptoJobs.co is the web's fastest growing crypto jobs discovery platform
 * [Cryptocurrency Jobs](https://cryptocurrencyjobs.co/) - The leading job board for blockchain and cryptocurrency jobs
 * [Blockchain Works](https://blockchain.works-hub.com/) - Discover **the best** Blockchain opportunities and articles with **Blockchain Works**
 * [Web3 Jobs](https://web3.career) - Looking for a web3 job? Web3 Jobs has 8,387+ web3 remote and offline jobs as Web3 Developer, Smart Contract Developer, Solidity Developer and much more. Switch your career to Web3 and join the future!
@@ -96,7 +95,6 @@ A curated list of awesome niche job boards.
 
 * [findwork.dev](https://findwork.dev/)
 * [Levels.fyi](https://www.levels.fyi/jobs)
-* [Dev Employ](https://devemploy.com/) - Hand-picked developer jobs
 
 ### Clojure
 
@@ -104,7 +102,6 @@ A curated list of awesome niche job boards.
 
 ### Functional
 
-* [FunctionalJobs.dev](https://functionaljobs.dev/) - Highly active job board for functional programming enthusiasts
 * [Functional Jobs](https://www.functionaljobs.com/) - Job board for functional programmers
 * [Functional Works](https://functional.works-hub.com/) - Discover local and remote functional programming opportunities
 
@@ -149,7 +146,6 @@ A curated list of awesome niche job boards.
 
 ### Ruby
 
-* [RubyNow](https://jobs.rubynow.com/)
 * [RubyOnRemote](https://rubyonremote.com) - Remote jobs for Ruby developers
 
 ### Rust
@@ -197,7 +193,6 @@ A curated list of awesome niche job boards.
 
 * [Relocate.me](https://relocate.me/) - Verified relocation packages
 * [underpin](https://www.underpin.company/) - Tech jobs and job search advice from an actual recruiter
-* [Fossfox](https://fossfox.com/) - Opportunities to work with companies that embrace open-source
 
 ### Canada
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,6 @@ A curated list of awesome niche job boards.
 * [findwork.dev](https://findwork.dev/)
 * [Levels.fyi](https://www.levels.fyi/jobs)
 * [Dev Employ](https://devemploy.com/) - Hand-picked developer jobs
-* [androiddev.careers](https://androiddev.careers/) – Job board for Android developers
 
 ### Clojure
 
@@ -125,6 +124,10 @@ A curated list of awesome niche job boards.
 * [Svelte Jobs](https://sveltejobs.com/)
 * [Javascript Works](https://javascript.works-hub.com/) - Local and remote JavaScript opportunities, articles and open-source
 * [JSJobbs](https://jsjobbs.com/)
+
+### Mobile
+
+* [androiddev.careers](https://androiddev.careers/) – Job board for Android developers
 
 ### Perl
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ A curated list of awesome niche job boards.
 
 * [findwork.dev](https://findwork.dev/)
 * [Levels.fyi](https://www.levels.fyi/jobs)
+* [Mecruit Job Board](https://www.mecruit.com/)
 
 ### Clojure
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ A curated list of awesome niche job boards.
 ### Mobile
 
 * [androiddev.careers](https://androiddev.careers/) – Job board for Android developers
+* [Mobile Career](https://mobile.career/) - Job board for mobile developers. iOS. Android. Flutter. React Native...
 
 ### Perl
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ A curated list of awesome niche job boards.
 * [Authentic Jobs](https://authenticjobs.com/) - "The leading job board for designers, hackers, and creative pros."
 * [Behance](https://www.behance.net/joblist)
 * [Coroflot](https://www.coroflot.com/design-jobs)
-* [IXDA](https://www.ixda.org/jobs/)
 * [Jobs for Designers](https://dribbble.com/jobs)
 * [Open Source Design Jobs](https://opensourcedesign.net/jobs/)
 * [UX Jobs Board](https://www.uxjobsboard.com)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A curated list of awesome niche job boards.
 
 * [AI Jobs](https://aijobs.app) – Jobs in Artificial Intelligence (AI)
 * [ai-jobs.net](https://ai-jobs.net/) - Jobs in AI and Big Data
-* [thrive](https://thriveml.com) - Jobs at Top AI Companies and Startups
+* [AI/ML Jobs](https://aimljobs.fyi) - Jobs at Top AI Companies and Startups
 * [AI Jobs Board](https://aijobsboard.net) - Jobs in AI/ML
 
 ## Big Data

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ A curated list of awesome niche job boards.
 ## Artificial Intelligence (AI)
 
 * [AI Jobs](https://www.moaijobs.com/) - AI Jobs in ML, Data Science, Engineering, and Research
-* [AI Jobs Dev](https://aijobs.dev) - Discover companies looking to hire AI, ML, Data Science & Big Data engineers and connect with them
 * [AI Jobs](https://aijobs.app) – Jobs in Artificial Intelligence (AI)
 * [aijobs.net](https://aijobs.net/) - Jobs in AI and Big Data
 * [AI/ML Jobs](https://www.aimljobs.fyi) - Jobs at Top AI Companies and Startups, Updated Daily!
@@ -32,7 +31,6 @@ A curated list of awesome niche job boards.
 ## Big Data
 
 * [DataJobs.com](https://datajobs.com/)
-* [Data Yoshi](https://www.datayoshi.com/) - Jobs in Data Science, Analytics, AI and Machine Learning
 * [Deep Learning Jobs](https://www.deeplearningjobs.com/) - Jobs in Deep Learning
 * [Wait, What Do You Do?](https://waitwhatdoyoudo.com/) - Jobs in data science, analytics, and engineering where you know what you'll really be doing
 * [Data Science Jobs Canada](https://www.datasciencejobscanada.com/) - Jobs in Data Science, Data Engineering, Data Analysis, AI, and Machine Learning
@@ -85,10 +83,6 @@ A curated list of awesome niche job boards.
 ## Gaming
 
 * [Work With Indies](https://www.workwithindies.com) - A single place find all the cool jobs in indie games
-
-## Growth Hacking
-
-* [GrowthHackers](https://jobs.growthhackers.com/)
 
 ## InfoSec
 
@@ -184,7 +178,6 @@ A curated list of awesome niche job boards.
 * [whoishiring.io](https://whoishiring.io/)
 * [remote4me.com](https://remote4me.com/)
 * [TheRemoteWork](https://theremotework.co/)
-* [MarketRemotely](https://marketremotely.com/) - Remote marketing jobs from all over the internet
 * [OkJob](https://okjob.io/) - 4 day week job board
 
 ## Startups

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ A curated list of awesome niche job boards.
 * [Remote Web3 Jobs](https://remote3.co) - A remote web3 job board onboarding people to web3 sharing web3 content, guides & tutorials for free.
 * [My Web3 Jobs](https://myweb3jobs.com) - Find or Post web3 Jobs Today! New web3 Blockchain, Developer, and Designer Jobs handpicked every week.
 * [Woody3](https://www.woodyjobs.com) - Find your dream non-tech job in Web3
+* [Jobs In Blockchains](https://jobsinblockchains.com) - Discover latest Blockchain, Web3, Smart Contracts, Defi, NFT, Cryptocurrency related jobs.
 
 ## Cloud
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ A curated list of awesome niche job boards.
 - [Artificial Intelligence (AI)](#artificial-intelligence-ai)
 - [Big Data](#big-data)
 - [Blockchain](#blockchain)
-- [Database](#database)
 - [Design](#design)
 - [DevOps](#devops)
 - [eCommerce](#ecommerce)
@@ -15,6 +14,7 @@ A curated list of awesome niche job boards.
 - [Gaming](#gaming)
 - [Growth Hacking](#growth-hacking)
 - [InfoSec](#infosec)
+- [Open Source](#opensource)
 - [Programming](#programming)
 - [Remote](#remote)
 - [Tech](#tech)
@@ -25,7 +25,6 @@ A curated list of awesome niche job boards.
 
 * [AI Jobs](https://www.moaijobs.com/) - AI Jobs in ML, Data Science, Engineering, and Research
 * [AI Jobs](https://aijobs.app) – Jobs in Artificial Intelligence (AI)
-* [aijobs.net](https://aijobs.net/) - Jobs in AI and Big Data
 * [AI/ML Jobs](https://www.aimljobs.fyi) - Jobs at Top AI Companies and Startups, Updated Daily!
 * [AI Jobster](https://aijobster.work/) - Jobs from leading AI companies, across all group.
 
@@ -44,19 +43,14 @@ A curated list of awesome niche job boards.
 * [Cryptocurrency Jobs](https://cryptocurrencyjobs.co/) - The leading job board for blockchain and cryptocurrency jobs
 * [Blockchain Works](https://blockchain.works-hub.com/) - Discover **the best** Blockchain opportunities and articles with **Blockchain Works**
 * [Web3 Jobs](https://web3.career) - Looking for a web3 job? Web3 Jobs has 8,387+ web3 remote and offline jobs as Web3 Developer, Smart Contract Developer, Solidity Developer and much more. Switch your career to Web3 and join the future!
-* [Remote Web3 Jobs](https://remote3.co) - A remote web3 job board onboarding people to web3 sharing web3 content, guides & tutorials for free
+* [Remote Web3 Jobs](https://remote3.co/) - A remote web3 job board onboarding people to web3 sharing web3 content, guides & tutorials for free
 * [My Web3 Jobs](https://myweb3jobs.com) - Find or Post web3 Jobs Today! New web3 Blockchain, Developer, and Designer Jobs handpicked every week
 * [Woody3](https://www.woodyjobs.com) - Find your dream non-tech job in Web3
 * [Jobs In Blockchain](https://jobsinblockchain.com) - Discover latest Blockchain, Web3, Smart Contracts, Defi, NFT, Cryptocurrency related jobs
 
 ## Cloud
 
-* [CNCF Job Board](https://jobs.cncf.io/) - Kubernetes and cloud native jobs
 * [Cloud Careers Hub](https://cloudcareershub.com/) - Job board for all roles related to Cloud Computing & Artificial Intelligence 
-
-## Database
-
-* [Webscale Jobs](https://www.webscale.work/) - Find a career working with MongoDB
 
 ## Design
 
@@ -89,7 +83,10 @@ A curated list of awesome niche job boards.
 ## InfoSec
 
 * [NinjaJobs](https://ninjajobs.org/) - A community-run job platform developed by InfoSec professionals
-* [isecjobs.com](https://isecjobs.com/) - A fresh and lean InfoSec jobs board
+
+## Open Source
+
+* [GitJobs](https://gitjobs.dev ) - Discover Open Source job opportunities
 
 ## Programming
 
@@ -97,7 +94,6 @@ A curated list of awesome niche job boards.
 
 * [findwork.dev](https://findwork.dev/)
 * [Levels.fyi](https://www.levels.fyi/jobs)
-* [Mecruit Job Board](https://www.mecruit.com/)
 
 ### Clojure
 
@@ -143,7 +139,6 @@ A curated list of awesome niche job boards.
 
 * [PyJobs](https://www.pyjobs.com)
 * [Python Job Board](https://www.python.org/jobs/)
-* [Django Jobs](https://djangojobs.net/jobs/)
 * [Python Developer Jobs](https://pythonjob.xyz)
 
 ### Ruby
@@ -174,7 +169,6 @@ A curated list of awesome niche job boards.
 * [Devremote](https://devremote.io/) - Remote developer jobs at remote first companies
 * [RemoteFR](https://remotefr.com/) - Full Remote jobs for French people 
 
-
 ### Aggregator
 
 * [4 day week](https://4dayweek.io/) - Software jobs with a better work-life balance
@@ -195,9 +189,7 @@ A curated list of awesome niche job boards.
 
 * [Relocate.me](https://relocate.me/) - Verified relocation packages
 * [Christian Tech Jobs](https://www.christiantechjobs.io/) - Tech jobs at Christian companies
-
-### Africa
-* [Hired Jobs](https://www.hired.co.ke) - Jobs in all available job categories. Both remote and onsite jobs.
+* [foo🦍](https://foorilla.com) - The go-to, no-nonsense, fast and lean career platform for all things coding, data and tech
 
 ### Canada
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ A curated list of awesome niche job boards.
 ### Aggregator
 
 * [findwork.dev](https://findwork.dev/)
+* [Levels.fyi](https://www.levels.fyi/jobs)
 
 ### Clojure
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ A curated list of awesome niche job boards.
 
 ## eCommerce
 
-* [eComPortal] (https://ecomportal.co) - Job board for the eCommerce Industry. Lots of front-end & full-stack developer job opportunities. Remote & Salary available. 
+* [eComPortal] (https://ecomportal.co/) - Job board for the eCommerce Industry. Lots of front-end & full-stack developer job opportunities. Remote & Salary available. 
 
 ## Finance
 
@@ -88,10 +88,6 @@ A curated list of awesome niche job boards.
 
 * [NinjaJobs](https://ninjajobs.org/) - A community-run job platform developed by InfoSec professionals
 * [infosec-jobs.com](https://infosec-jobs.com/) - A fresh and lean InfoSec jobs board
-
-## Metaverse
-
-* [Hire.AR](https://www.hire.ar/) - Job board for Augmented Reality jobs
 
 ## Machine Learning
 
@@ -121,7 +117,6 @@ A curated list of awesome niche job boards.
 ### Go
 
 * [Golangprojects](https://www.golangprojects.com/)- Golang jobs since 2014, also got a remote section
-* [we love golang](https://www.welovegolang.com/)
 * [Golang Forum Jobs](https://forum.golangbridge.org/c/jobs/8)
 * [Golang Developer Jobs](https://golangjob.xyz)
 * [Golang Works](https://golang.works-hub.com/) - Local and remote Golang opportunities, articles and open-source.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ A curated list of awesome niche job boards.
 ## Cloud
 
 * [CNCF Job Board](https://jobs.cncf.io/) - Kubernetes and cloud native jobs
+* [Cloud Careers Hub](https://cloudcareershub.com/) - Job board for all roles related to Cloud Computing & Artificial Intelligence 
 
 ## Design
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ A curated list of awesome niche job boards.
 * [UX Jobs Board](https://www.uxjobsboard.com)
 * [UI & UX Designer Jobs](https://uiuxdesignerjobs.com/) | Hand-picked UI, UX & UXR Jobs
 * [UI/UX Jobs Board](https://uiuxjobsboard.com/)
+* [CreativeFuego Jobs](https://creativefuego.com/jobs) | Curated Design and Creative Jobs
 
 ## DevOps
 

--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ A curated list of awesome niche job boards.
 
 * [Relocate.me](https://relocate.me/) - Verified relocation packages
 * [underpin](https://www.underpin.company/) - Tech jobs and job search advice from an actual recruiter
+* [Christian Tech Jobs](https://www.christiantechjobs.io/) - Tech jobs at Christian companies
 
 ### Canada
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ A curated list of awesome niche job boards.
 * [Wait, What Do You Do?](https://waitwhatdoyoudo.com/) - Jobs in data science, analytics, and engineering where you know what you'll really be doing
 * [Data Science Jobs Canada](https://www.datasciencejobscanada.com/) - Jobs in Data Science, Data Engineering, Data Analysis, AI, and Machine Learning
 * [DataScienceJobs](https://datasciencejobs.com/) - Discover the latest and greatest data science jobs.
-* [AiJobsTracker](https://www.aijobs.18offers.com/) | live aggregator of 400+ AI-first companies's job boards, updated daily.
+* [AiJobsTracker](https://aijobs.18offers.com/) | live aggregator of 400+ AI-first companies's job boards, updated daily.
 
 
 ## Blockchain

--- a/README.md
+++ b/README.md
@@ -50,10 +50,6 @@ A curated list of awesome niche job boards.
 
 * [CNCF Job Board](https://jobs.cncf.io/) - Kubernetes and cloud native jobs
 
-## Customer Support
-
-* [Support Driven Jobs](https://jobs.supportdriven.com/)
-
 ## Design
 
 * [AIGA](https://designjobs.aiga.org/)
@@ -113,10 +109,6 @@ A curated list of awesome niche job boards.
 ### Full-Stack
 
 * [Full-Stack Developer Jobs](https://fullstackjob.com/) - Job board for Full-Stack Developers
-
-### Frontend
-
-* [Frontend Careers](https://frontendcareers.com/) - Job board for Frontend Developers
 
 ### Functional
 
@@ -209,7 +201,6 @@ A curated list of awesome niche job boards.
 ## Tech
 
 * [Free & Open Source Jobs](https://www.fossjobs.net/)
-* [GOODJOBS](https://goodjobs.careers/) - A job board with hand-picked engineering positions at companies trying to fix problems like climate-change and food insecurity
 * [Relocate.me](https://relocate.me/) - Verified relocation packages
 * [underpin](https://www.underpin.company/) - Tech jobs and job search advice from an actual recruiter
 

--- a/README.md
+++ b/README.md
@@ -194,7 +194,6 @@ A curated list of awesome niche job boards.
 ## Tech
 
 * [Relocate.me](https://relocate.me/) - Verified relocation packages
-* [underpin](https://www.underpin.company/) - Tech jobs and job search advice from an actual recruiter
 * [Christian Tech Jobs](https://www.christiantechjobs.io/) - Tech jobs at Christian companies
 
 ### Africa

--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ A curated list of awesome niche job boards.
 * [remote4me.com](https://remote4me.com/)
 * [TheRemoteWork](https://theremotework.co/)
 * [MarketRemotely](https://marketremotely.com/) - Remote marketing jobs from all over the internet
+* [OkJob](https://okjob.io/) - 4 day week job board
 
 ## Startups
 

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ A curated list of awesome niche job boards.
 * [Free & Open Source Jobs](https://www.fossjobs.net/)
 * [Relocate.me](https://relocate.me/) - Verified relocation packages
 * [underpin](https://www.underpin.company/) - Tech jobs and job search advice from an actual recruiter
-* [Fossfox](https://fossfox.com/) - Opportunity explorer for open-source devs
+* [Fossfox](https://fossfox.com/) - Opportunities to work with companies that embrace open-source
 
 ### Canada
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A curated list of awesome niche job boards.
 
 ## Artificial Intelligence (AI)
 
-* [AI Jobs Dev](https://aijobs.dev) - Discover companies looking to hire AI, ML, Data Science & Big Data engineers and connect with them.
+* [AI Jobs Dev](https://aijobs.dev) - Discover companies looking to hire AI, ML, Data Science & Big Data engineers and connect with them
 * [AI Jobs](https://aijobs.app) – Jobs in Artificial Intelligence (AI)
 * [ai-jobs.net](https://ai-jobs.net/) - Jobs in AI and Big Data
 * [thrive](https://thriveml.com) - Jobs at Top AI Companies and Startups
@@ -35,19 +35,19 @@ A curated list of awesome niche job boards.
 * [Deep Learning Jobs](https://www.deeplearningjobs.com/) - Jobs in Deep Learning
 * [Wait, What Do You Do?](https://waitwhatdoyoudo.com/) - Jobs in data science, analytics, and engineering where you know what you'll really be doing
 * [Data Science Jobs Canada](https://www.datasciencejobscanada.com/) - Jobs in Data Science, Data Engineering, Data Analysis, AI, and Machine Learning
-* [DataScienceJobs](https://datasciencejobs.com/) - Discover the latest and greatest data science jobs.
+* [DataScienceJobs](https://datasciencejobs.com/) - Discover the latest and greatest data science jobs
 
 ## Blockchain
 
-* [Crypto Jobs List](https://cryptojobslist.com/) - Crypto Jobs List is your #1 board to find and post crypto, bitcoin and blockchain jobs.
-* [Crypto Jobs](https://www.cryptojobs.co/) - CryptoJobs.co is the web's fastest growing crypto jobs discovery platform.
+* [Crypto Jobs List](https://cryptojobslist.com/) - Crypto Jobs List is your #1 board to find and post crypto, bitcoin and blockchain jobs
+* [Crypto Jobs](https://www.cryptojobs.co/) - CryptoJobs.co is the web's fastest growing crypto jobs discovery platform
 * [Cryptocurrency Jobs](https://cryptocurrencyjobs.co/) - The leading job board for blockchain and cryptocurrency jobs
 * [Blockchain Works](https://blockchain.works-hub.com/) - Discover **the best** Blockchain opportunities and articles with **Blockchain Works**
 * [Web3 Jobs](https://web3.career) - Looking for a web3 job? Web3 Jobs has 8,387+ web3 remote and offline jobs as Web3 Developer, Smart Contract Developer, Solidity Developer and much more. Switch your career to Web3 and join the future!
-* [Remote Web3 Jobs](https://remote3.co) - A remote web3 job board onboarding people to web3 sharing web3 content, guides & tutorials for free.
-* [My Web3 Jobs](https://myweb3jobs.com) - Find or Post web3 Jobs Today! New web3 Blockchain, Developer, and Designer Jobs handpicked every week.
+* [Remote Web3 Jobs](https://remote3.co) - A remote web3 job board onboarding people to web3 sharing web3 content, guides & tutorials for free
+* [My Web3 Jobs](https://myweb3jobs.com) - Find or Post web3 Jobs Today! New web3 Blockchain, Developer, and Designer Jobs handpicked every week
 * [Woody3](https://www.woodyjobs.com) - Find your dream non-tech job in Web3
-* [Jobs In Blockchain](https://jobsinblockchain.com) - Discover latest Blockchain, Web3, Smart Contracts, Defi, NFT, Cryptocurrency related jobs.
+* [Jobs In Blockchain](https://jobsinblockchain.com) - Discover latest Blockchain, Web3, Smart Contracts, Defi, NFT, Cryptocurrency related jobs
 
 ## Cloud
 
@@ -56,7 +56,7 @@ A curated list of awesome niche job boards.
 ## Design
 
 * [AIGA](https://designjobs.aiga.org/)
-* [Authentic Jobs](https://authenticjobs.com/) - "The leading job board for designers, hackers, and creative pros."
+* [Authentic Jobs](https://authenticjobs.com/) - The leading job board for designers, hackers, and creative pros
 * [Behance](https://www.behance.net/joblist)
 * [Coroflot](https://www.coroflot.com/design-jobs)
 * [Jobs for Designers](https://dribbble.com/jobs)
@@ -66,7 +66,7 @@ A curated list of awesome niche job boards.
 
 ## DevOps
 
-* [Kube Careers](https://kube.careers) — Hand-picked Kubernetes jobs, clear salary ranges and apply directly to companies.
+* [Kube Careers](https://kube.careers) — Hand-picked Kubernetes jobs, clear salary ranges and apply directly to companies
 
 ## eCommerce
 
@@ -113,7 +113,7 @@ A curated list of awesome niche job boards.
 * [Golangprojects](https://www.golangprojects.com/)- Golang jobs since 2014, also got a remote section
 * [Golang Forum Jobs](https://forum.golangbridge.org/c/jobs/8)
 * [Golang Developer Jobs](https://golangjob.xyz)
-* [Golang Works](https://golang.works-hub.com/) - Local and remote Golang opportunities, articles and open-source.
+* [Golang Works](https://golang.works-hub.com/) - Local and remote Golang opportunities, articles and open-source
 
 ### JavaScript
 
@@ -122,7 +122,7 @@ A curated list of awesome niche job boards.
 * [Vue.js Jobs](https://vuejobs.com/)
 * [React Jobs](https://reactjsjob.com)
 * [Svelte Jobs](https://sveltejobs.com/)
-* [Javascript Works](https://javascript.works-hub.com/) - Local and remote JavaScript opportunities, articles and open-source.
+* [Javascript Works](https://javascript.works-hub.com/) - Local and remote JavaScript opportunities, articles and open-source
 * [JSJobbs](https://jsjobbs.com/)
 
 ### Perl
@@ -150,8 +150,8 @@ A curated list of awesome niche job boards.
 
 ### Rust
 
-* [Rust Jobs](https://www.rustjobs.com)
-* [Rust Jobs](https://rustjobs.dev)
+* [Rust Jobs](https://www.rustjobs.com) - A job board dedicated to the Rust programming language
+* [Rust Jobs](https://rustjobs.dev) - The go-to hiring platform for Rust engineering talent
 * [Rust Jobs - Remote and OnSite](https://rustjob.xyz)
 
 ### Scala
@@ -208,7 +208,7 @@ A curated list of awesome niche job boards.
 
 ### United Kingdom
 
-* [IT Jobs Watch](https://www.itjobswatch.co.uk/) - Includes free technology skill set trends, salary/contractor rate benchmarking and real-time job vacancy statistics.
+* [IT Jobs Watch](https://www.itjobswatch.co.uk/) - Includes free technology skill set trends, salary/contractor rate benchmarking, and real-time job vacancy statistics
 
 ## Writing
 

--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ A curated list of awesome niche job boards.
 ## Remote
 
 * [100% Work From Anywhere jobs](https://www.realworkfromanywhere.com/) - Fully remote jobs to live and work from anywhere
+* [Better Remote Jobs](https://betterremotejobs.com/) - Remote Jobs without any paywall or account signup
 * [We Work Remotely](https://weworkremotely.com/)
 * [DailyRemote](https://dailyremote.com/)
 * [Werkington](https://www.werkington.com/)

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ A curated list of awesome niche job boards.
 
 * [findwork.dev](https://findwork.dev/)
 * [Levels.fyi](https://www.levels.fyi/jobs)
+* [Dev Employ](https://www.devemploy.com)
 
 ### Clojure
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A curated list of awesome niche job boards.
 
 * [AI Jobs](https://aijobs.app) – Jobs in Artificial Intelligence (AI)
 * [ai-jobs.net](https://ai-jobs.net/) - Jobs in AI and Big Data
-* [AI/ML Jobs](https://aimljobs.fyi) - Jobs at Top AI Companies and Startups, Updated Daily!
+* [AI/ML Jobs](https://www.aimljobs.fyi) - Jobs at Top AI Companies and Startups, Updated Daily!
 * [AI Jobs Board](https://aijobsboard.net) - Jobs in AI/ML
 
 ## Big Data

--- a/README.md
+++ b/README.md
@@ -226,4 +226,4 @@ A curated list of awesome niche job boards.
 ## Various
 * [WorkInGreen.jobs](https://workingreen.jobs/) - Greentech related jobs
 * [Privacy-First Jobs](https://privacyfirstjobs.com/) – Jobs in privacy-first companies and organisations.
-* * [ClimateTechList](https://www.climatetechlist.com/) - climate tech / green energy jobs for software engineers, PMs, & other tech professionals, live aggregator of 600 companies' job boards, updated daily.
+* [ClimateTechList](https://www.climatetechlist.com/) - climate tech / green energy jobs for software engineers, PMs, & other tech professionals, live aggregator of 600 companies' job boards, updated daily.

--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ A curated list of awesome niche job boards.
 * [GermanTech Jobs](https://germantechjobs.de/) - Dedicated Tech Job Board for Germany
 * [SwissDev Jobs](https://swissdevjobs.ch/) - Jobs for Software Developers from the EU that want to work in Switzerland
 * [WeJob.ch](https://WeJob.ch/?utm_source=github&utm_medium=referral&utm_campaign=tramcar-awesome-job-boards) - Developers and IT Jobs in Switzerland 🇨🇭
+* [Next Level Jobs EU](https://nextleveljobs.eu/?utm_source=github&utm_medium=referral&utm_campaign=tramcar-awesome-job-boards) -  €100k+ Software Engineering Jobs 🇪🇺
 
 ### United Kingdom
 

--- a/README.md
+++ b/README.md
@@ -224,6 +224,6 @@ A curated list of awesome niche job boards.
 * [Write the Docs Job Board](https://jobs.writethedocs.org/) - Jobs for people who care about documentation
 
 ## Various
-* [ClimateTechList](https://www.climatetechlist.com/) - climate tech / green energy jobs for software engineers, PMs, & other tech professionals, live aggregator of 600 companies' job boards, updated daily
 * [WorkInGreen.jobs](https://workingreen.jobs/) - Greentech related jobs
 * [Privacy-First Jobs](https://privacyfirstjobs.com/) – Jobs in privacy-first companies and organisations.
+* * [ClimateTechList](https://www.climatetechlist.com/) - climate tech / green energy jobs for software engineers, PMs, & other tech professionals, live aggregator of 600 companies' job boards, updated daily.

--- a/README.md
+++ b/README.md
@@ -123,7 +123,6 @@ A curated list of awesome niche job boards.
 * [Jobs In JS](https://jobsinjs.com/)
 * [JavaScript Developer Board](https://javascriptjob.xyz/)
 * [Vue.js Jobs](https://vuejobs.com/)
-* [React Jobs](https://reactjsjob.com)
 * [Svelte Jobs](https://sveltejobs.com/)
 * [Javascript Works](https://javascript.works-hub.com/) - Local and remote JavaScript opportunities, articles and open-source
 * [JSJobbs](https://jsjobbs.com/)

--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ A curated list of awesome niche job boards.
 * [Free & Open Source Jobs](https://www.fossjobs.net/)
 * [Relocate.me](https://relocate.me/) - Verified relocation packages
 * [underpin](https://www.underpin.company/) - Tech jobs and job search advice from an actual recruiter
+* [Fossfox](https://fossfox.com/) - Opportunity explorer for open-source devs
 
 ### Canada
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ A curated list of awesome niche job boards.
 * [AI Jobs](https://aijobs.app) – Jobs in Artificial Intelligence (AI)
 * [ai-jobs.net](https://ai-jobs.net/) - Jobs in AI and Big Data
 * [thrive](https://thriveml.com) - Jobs at Top AI Companies and Startups
-* [Best AI Jobs](https://bestaijobs.com) - Best AI Jobs from 100+ AI Startups
 * [AI Jobs Board](https://aijobsboard.net) - Jobs in AI/ML
 
 ## Big Data
@@ -36,7 +35,6 @@ A curated list of awesome niche job boards.
 * [Deep Learning Jobs](https://www.deeplearningjobs.com/) - Jobs in Deep Learning
 * [Wait, What Do You Do?](https://waitwhatdoyoudo.com/) - Jobs in data science, analytics, and engineering where you know what you'll really be doing
 * [Data Science Jobs Canada](https://www.datasciencejobscanada.com/) - Jobs in Data Science, Data Engineering, Data Analysis, AI, and Machine Learning
-* [AiJobsTracker](https://www.aijobstracker.com/) - live aggregator of 300+ AI-first companies's job boards, updated daily.
 * [DataScienceJobs](https://datasciencejobs.com/) - Discover the latest and greatest data science jobs.
 
 ## Blockchain
@@ -91,10 +89,6 @@ A curated list of awesome niche job boards.
 * [NinjaJobs](https://ninjajobs.org/) - A community-run job platform developed by InfoSec professionals
 * [infosec-jobs.com](https://infosec-jobs.com/) - A fresh and lean InfoSec jobs board
 
-## Machine Learning
-
-* [Jobhunt.ai](https://jobhunt.ai/) - Machine learning and data science jobs, also got a remote section
-
 ## Programming
 
 ### Aggregator
@@ -125,7 +119,6 @@ A curated list of awesome niche job boards.
 * [Jobs In JS](https://jobsinjs.com/)
 * [JavaScript Developer Board](https://javascriptjob.xyz/)
 * [Vue.js Jobs](https://vuejobs.com/)
-* [We Work Meteor](https://www.weworkmeteor.com/)
 * [React Jobs](https://reactjsjob.com)
 * [Svelte Jobs](https://sveltejobs.com/)
 * [Javascript Works](https://javascript.works-hub.com/) - Local and remote JavaScript opportunities, articles and open-source.

--- a/README.md
+++ b/README.md
@@ -158,9 +158,6 @@ A curated list of awesome niche job boards.
 ### Scala
 * [Scala Jobs](https://scalajobs.com)
 
-### TypeScript
-* [TypeScript Jobs](https://typescriptjobs.dev)
-
 ## Remote
 
 * [100% Work From Anywhere jobs](https://www.realworkfromanywhere.com/) - Fully remote jobs to live and work from anywhere

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ A curated list of awesome niche job boards.
 * [ai-jobs.net](https://ai-jobs.net/) - Jobs in AI and Big Data
 * [thrive](https://thriveml.com) - Jobs at Top AI Companies and Startups
 * [Best AI Jobs](https://bestaijobs.com) - Best AI Jobs from 100+ AI Startups
+* [AI Jobs Board](https://aijobsboard.net) - Jobs in AI/ML
 
 ## Big Data
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ A curated list of awesome niche job boards.
 * [findwork.dev](https://findwork.dev/)
 * [Levels.fyi](https://www.levels.fyi/jobs)
 * [Dev Employ](https://devemploy.com/) - Hand-picked developer jobs
-* [androiddev.careers](http://androiddev.careers/) – Job board for Android developers
+* [androiddev.careers](https://androiddev.careers/) – Job board for Android developers
 
 ### Clojure
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A curated list of awesome niche job boards.
 
 ## Artificial Intelligence (AI)
 
+* [AI Jobs Dev](https://aijobs.dev) - Discover companies looking to hire AI, ML, Data Science & Big Data engineers and connect with them.
 * [AI Jobs](https://aijobs.app) – Jobs in Artificial Intelligence (AI)
 * [ai-jobs.net](https://ai-jobs.net/) - Jobs in AI and Big Data
 * [thrive](https://thriveml.com) - Jobs at Top AI Companies and Startups

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ A curated list of awesome niche job boards.
 
 ### Rust
 
+* [Rust Jobs](https://www.rustjobs.com)
 * [Rust Jobs](https://rustjobs.dev)
 * [Rust Jobs - Remote and OnSite](https://rustjob.xyz)
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A curated list of awesome niche job boards.
 - [InfoSec](#infosec)
 - [Programming](#programming)
 - [Remote](#remote)
+- [Quantum Computing)(#quantum-computing)
 - [Tech](#tech)
 - [Writing](#writing)
 - [Various](#various)
@@ -174,6 +175,9 @@ A curated list of awesome niche job boards.
 * [Devremote](https://devremote.io/) - Remote developer jobs at remote first companies
 * [RemoteFR](https://remotefr.com/) - Full Remote jobs for French people 
 
+## Quantum Computing
+
+* [qubitsok.com](https://qubitsok.com/) - A job board specialized in Quantum Computing with personalized job alerts
 
 ### Aggregator
 

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ A curated list of awesome niche job boards.
 
 ## Artificial Intelligence (AI)
 
+* [AI Jobs](https://www.moaijobs.com/) - AI Jobs in ML, Data Science, Engineering, and Research
 * [AI Jobs Dev](https://aijobs.dev) - Discover companies looking to hire AI, ML, Data Science & Big Data engineers and connect with them
 * [AI Jobs](https://aijobs.app) – Jobs in Artificial Intelligence (AI)
 * [ai-jobs.net](https://ai-jobs.net/) - Jobs in AI and Big Data
 * [AI/ML Jobs](https://www.aimljobs.fyi) - Jobs at Top AI Companies and Startups, Updated Daily!
-* [AI Jobs Board](https://aijobsboard.net) - Jobs in AI/ML
 
 ## Big Data
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ A curated list of awesome niche job boards.
 
 * [findwork.dev](https://findwork.dev/)
 * [Levels.fyi](https://www.levels.fyi/jobs)
-* [Dev Employ](https://www.devemploy.com)
+* [Dev Employ](https://devemploy.com/) - Hand-picked developer jobs
 
 ### Clojure
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,9 @@ A curated list of awesome niche job boards.
 ### Scala
 * [Scala Jobs](https://scalajobs.com)
 
+### Java
+* [JavaProHire](https://javaprohire.com/) - A job board crafted with a laser focus on Java developers
+
 ### TypeScript
 * [TypeScript Jobs](https://typescriptjobs.dev)
 

--- a/README.md
+++ b/README.md
@@ -213,6 +213,8 @@ A curated list of awesome niche job boards.
 * [GermanTech Jobs](https://germantechjobs.de/) - Dedicated Tech Job Board for Germany
 * [SwissDev Jobs](https://swissdevjobs.ch/) - Jobs for Software Developers from the EU that want to work in Switzerland
 * [WeJob.ch](https://WeJob.ch/?utm_source=github&utm_medium=referral&utm_campaign=tramcar-awesome-job-boards) - Developers and IT Jobs in Switzerland 🇨🇭
+* [DanishTech.co](https://danishtech.co/?utm_source=github&utm_medium=referral&utm_campaign=tramcar-awesome-job-boards) - Dedicated Tech Job Board for Denmark 🇩🇰
+
 
 ### United Kingdom
 

--- a/README.md
+++ b/README.md
@@ -217,4 +217,4 @@ A curated list of awesome niche job boards.
 ## Various
 * [WorkInGreen.jobs](https://workingreen.jobs/) - Greentech related jobs
 * [ClimateTechList](https://www.climatetechlist.com/) - Comprehensive aggregator of 30,000+ job openings from 1,000 climate tech/clean energy companies' job boards, updated daily
-* [FoundRole](https://foundrole.com/) – AI-powered job search platform and job application tracker for knowledge workers.
+* [FoundRole](https://www.foundrole.com/) – AI-powered job search platform and job application tracker for knowledge workers.

--- a/README.md
+++ b/README.md
@@ -168,11 +168,7 @@ A curated list of awesome niche job boards.
 * [whoishiring.io](https://whoishiring.io/)
 * [remote4me.com](https://remote4me.com/)
 * [TheRemoteWork](https://theremotework.co/)
-<<<<<<< master
-* [OkJob](https://okjob.io/) - 4 day week job board
 * [devtooljobs](https://devtooljobs.com/) - GTM jobs in developer tooling companies
-=======
->>>>>>> master
 
 ## Startups
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,8 @@ A curated list of awesome niche job boards.
 * [Dynamite Jobs](https://dynamitejobs.com/) - Jobs from remote-first companies
 * [Teletravail.guru](https://teletravail.guru/) - Remote jobs for people located in France
 * [Devremote](https://devremote.io/) - Remote developer jobs at remote first companies
-* [RemoteFR](https://remotefr.com/) - Full Remote jobs for French people 
+* [RemoteFR](https://remotefr.com/) - Full Remote jobs for French people
+* [4DayJob](https://4dayjob.com/) - 4-day work week and remote job board with 1,500+ flexible opportunities
 
 ## Quantum Computing
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ A curated list of awesome niche job boards.
 - [Finance](#finance)
 - [Gaming](#gaming)
 - [Growth Hacking](#growth-hacking)
-- [InfoSec](#infosec)
 - [Open Source](#opensource)
 - [Programming](#programming)
 - [Remote](#remote)
@@ -76,10 +75,6 @@ A curated list of awesome niche job boards.
 
 * [Work With Indies](https://www.workwithindies.com) - A single place find all the cool jobs in indie games
 
-## InfoSec
-
-* [NinjaJobs](https://ninjajobs.org/) - A community-run job platform developed by InfoSec professionals
-
 ## Open Source
 
 * [GitJobs](https://gitjobs.dev ) - Discover Open Source job opportunities
@@ -109,7 +104,6 @@ A curated list of awesome niche job boards.
 ### JavaScript
 
 * [Jobs In JS](https://jobsinjs.com/)
-* [JavaScript Developer Board](https://javascriptjob.xyz/)
 * [Vue.js Jobs](https://vuejobs.com/)
 * [Svelte Jobs](https://sveltejobs.com/)
 * [Javascript Works](https://javascript.works-hub.com/) - Local and remote JavaScript opportunities, articles and open-source
@@ -117,7 +111,6 @@ A curated list of awesome niche job boards.
 
 ### Mobile
 
-* [androiddev.careers](https://androiddev.careers/) – Job board for Android developers
 * [Mobile Career](https://mobile.career/) - Job board for mobile developers. iOS. Android. Flutter. React Native...
 
 ### Perl
@@ -135,7 +128,6 @@ A curated list of awesome niche job boards.
 
 * [PyJobs](https://www.pyjobs.com)
 * [Python Job Board](https://www.python.org/jobs/)
-* [Python Developer Jobs](https://pythonjob.xyz)
 
 ### Ruby
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ A curated list of awesome niche job boards.
 
 ## Remote
 
+* [hiring.lat](https://hiring.lat/jobs) - 100% Remote jobs for LATAM professionals.
 * [100% Work From Anywhere jobs](https://www.realworkfromanywhere.com/) - Fully remote jobs to live and work from anywhere
 * [We Work Remotely](https://weworkremotely.com/)
 * [DailyRemote](https://dailyremote.com/)
@@ -197,6 +198,7 @@ A curated list of awesome niche job boards.
 
 ### Latin America
 
+* [hiring.lat](https://hiring.lat/jobs) - Fully remote jobs for Latin American talent.
 * [Findjobit](https://findjobit.com/jobs)
 
 ### United Kingdom

--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ A curated list of awesome niche job boards.
 * [remote4me.com](https://remote4me.com/)
 * [TheRemoteWork](https://theremotework.co/)
 * [OkJob](https://okjob.io/) - 4 day week job board
+* [devtooljobs](https://devtooljobs.com/) - GTM jobs in developer tooling companies
 
 ## Startups
 

--- a/README.md
+++ b/README.md
@@ -50,13 +50,9 @@ A curated list of awesome niche job boards.
 * [Woody3](https://www.woodyjobs.com) - Find your dream non-tech job in Web3
 * [Jobs In Blockchain](https://jobsinblockchain.com) - Discover latest Blockchain, Web3, Smart Contracts, Defi, NFT, Cryptocurrency related jobs
 
-## Cloud
-
-* [Cloud Careers Hub](https://cloudcareershub.com/) - Job board for all roles related to Cloud Computing & Artificial Intelligence 
-
 ## Design
 
-* [AIGA](https://designjobs.aiga.org/)
+* [AIGA](https://designcareers.aiga.org/)
 * [Authentic Jobs](https://authenticjobs.com/) - The leading job board for designers, hackers, and creative pros
 * [Behance](https://www.behance.net/joblist)
 * [Coroflot](https://www.coroflot.com/design-jobs)
@@ -65,7 +61,6 @@ A curated list of awesome niche job boards.
 * [UX Jobs Board](https://www.uxjobsboard.com)
 * [UI & UX Designer Jobs](https://uiuxdesignerjobs.com/) | Hand-picked UI, UX & UXR Jobs
 * [UI/UX Jobs Board](https://uiuxjobsboard.com/)
-* [CreativeFuego Jobs](https://creativefuego.com/jobs) | Curated Design and Creative Jobs
 
 ## DevOps
 
@@ -105,14 +100,12 @@ A curated list of awesome niche job boards.
 
 ### Functional
 
-* [FunctionalJobs.dev](https://functionaljobs.dev/) - Highly active job board for functional programming enthusiasts
 * [Functional Works](https://functional.works-hub.com/) - Discover local and remote functional programming opportunities
 
 ### Go
 
 * [Golangprojects](https://www.golangprojects.com/)- Golang jobs since 2014, also got a remote section
 * [Golang Forum Jobs](https://forum.golangbridge.org/c/jobs/8)
-* [Golang Developer Jobs](https://golangjob.xyz)
 * [Golang Works](https://golang.works-hub.com/) - Local and remote Golang opportunities, articles and open-source
 
 ### JavaScript
@@ -161,13 +154,11 @@ A curated list of awesome niche job boards.
 ## Remote
 
 * [100% Work From Anywhere jobs](https://www.realworkfromanywhere.com/) - Fully remote jobs to live and work from anywhere
-* [Better Remote Jobs](https://betterremotejobs.com/) - Remote Jobs without any paywall or account signup
 * [We Work Remotely](https://weworkremotely.com/)
 * [DailyRemote](https://dailyremote.com/)
 * [Werkington](https://www.werkington.com/)
 * [Just Remote](https://justremote.co/remote-jobs)
 * [Dynamite Jobs](https://dynamitejobs.com/) - Jobs from remote-first companies
-* [Teletravail.guru](https://teletravail.guru/) - Remote jobs for people located in France
 * [Devremote](https://devremote.io/) - Remote developer jobs at remote first companies
 * [RemoteFR](https://remotefr.com/) - Full Remote jobs for French people 
 
@@ -182,7 +173,6 @@ A curated list of awesome niche job boards.
 * [whoishiring.io](https://whoishiring.io/)
 * [remote4me.com](https://remote4me.com/)
 * [TheRemoteWork](https://theremotework.co/)
-* [OkJob](https://okjob.io/) - 4 day week job board
 
 ## Startups
 

--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ A curated list of awesome niche job boards.
 * [Christian Tech Jobs](https://www.christiantechjobs.io/) - Tech jobs at Christian companies
 * [EmbeddedJobs](https://embedded.jobs) - A niche job board exclusively for Embedded Systems engineers and developers.
 * [foo🦍](https://foorilla.com) - The go-to, no-nonsense, fast and lean career platform for all things coding, data and tech
+* [LeadJobs.dev](https://leadjobs.dev) - Software Engineering Leadership Jobs Board (only EM/Staff+ positions, VP, Director, CTO)
 
 ### Canada
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ A curated list of awesome niche job boards.
 * [AI/ML Jobs](https://www.aimljobs.fyi) - Jobs at Top AI Companies and Startups, Updated Daily!
 * [AI Jobster](https://aijobster.work/) - Jobs from leading AI companies, across all group.
 * [ExploreJobs.ai](https://explorejobs.ai) - Find engineering, product, and research roles at the top AI startups.
+* [AI Dev Jobs](https://aidevboard.com) - 7,400+ AI/ML jobs from 417 companies with a free REST API and MCP server for AI agents
 
 ## Big Data
 

--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ A curated list of awesome niche job boards.
 ### Canada
 
 * [Work in Tech](https://www1.communitech.ca/jobs) - Explore opportunities in Waterloo Region and beyond
+* [Hanzilla Jobs](https://jobs.hanzilla.co/) - Daily-updated Canadian student and recent-grad jobs across internships, co-ops, new grad, junior, and entry-level roles
 
 ### Europe
 

--- a/README.md
+++ b/README.md
@@ -226,3 +226,4 @@ A curated list of awesome niche job boards.
 ## Various
 * [WorkInGreen.jobs](https://workingreen.jobs/) - Greentech related jobs
 * [ClimateTechList](https://www.climatetechlist.com/) - Comprehensive aggregator of 30,000+ job openings from 1,000 climate tech/clean energy companies' job boards, updated daily
+* [FoundRole](https://foundrole.com/) – AI-powered job search platform and job application tracker for knowledge workers.

--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ A curated list of awesome niche job boards.
 * [DanishTech.co](https://danishtech.co/?utm_source=github&utm_medium=referral&utm_campaign=tramcar-awesome-job-boards) - Dedicated Tech Job Board for Denmark 🇩🇰
 * [Next Level Jobs EU](https://nextleveljobs.eu/?utm_source=github&utm_medium=referral&utm_campaign=tramcar-awesome-job-boards) - €100k+ Software Engineering Jobs 🇪🇺
 * [Work In Tech](https://www1.communitech.ca/jobs) - Find your next role at Canada's fastest-growing tech companies
+* [Defence jobs in Europe](https://www.defencejobs.org) - The main job board for European defence 🇪🇺
 
 ### Latin America
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ A curated list of awesome niche job boards.
 * [My Web3 Jobs](https://myweb3jobs.com) - Find or Post web3 Jobs Today! New web3 Blockchain, Developer, and Designer Jobs handpicked every week
 * [Woody3](https://www.woodyjobs.com) - Find your dream non-tech job in Web3
 * [Jobs In Blockchain](https://jobsinblockchain.com) - Discover latest Blockchain, Web3, Smart Contracts, Defi, NFT, Cryptocurrency related jobs
+* [GMI Jobs](https://gmijobs.com) - Crypto-native job board for Web3 professionals — curated roles from 200+ blockchain companies with AI-powered job enrichment.
 
 ## Cloud
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ A curated list of awesome niche job boards.
 * [AI/ML Jobs](https://www.aimljobs.fyi) - Jobs at Top AI Companies and Startups, Updated Daily!
 * [AI Jobster](https://aijobster.work/) - Jobs from leading AI companies, across all group.
 * [ExploreJobs.ai](https://explorejobs.ai) - Find engineering, product, and research roles at the top AI startups.
+* [Agentic Engineering Jobs](https://agentic-engineering-jobs.com) - Job board for engineers building agentic systems (RAG, AI agents, LLM-powered products, agent orchestration). Free to post, free to browse.
 
 ## Big Data
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ A curated list of awesome niche job boards.
 - [Blockchain](#blockchain)
 - [Design](#design)
 - [DevOps](#devops)
-- [eCommerce](#ecommerce)
 - [Finance](#finance)
 - [Gaming](#gaming)
 - [Growth Hacking](#growth-hacking)
@@ -65,10 +64,6 @@ A curated list of awesome niche job boards.
 ## DevOps
 
 * [Kube Careers](https://kube.careers) — Hand-picked Kubernetes jobs, clear salary ranges and apply directly to companies
-
-## eCommerce
-
-* [eComPortal](https://www.ecomportal.co/) - Job board for the eCommerce Industry. Lots of front-end & full-stack developer job opportunities. Remote & Salary available. 
 
 ## Finance
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ A curated list of awesome niche job boards.
 * [Just Remote](https://justremote.co/remote-jobs)
 * [Dynamite Jobs](https://dynamitejobs.com/) - Jobs from remote-first companies
 * [Devremote](https://devremote.io/) - Remote developer jobs at remote first companies
-* [RemoteFR](https://remotefr.com/) - Full Remote jobs for French people
+* [RemoteFR](https://remotefr.com/) - Full Remote jobs for French people 
 * [4DayJob](https://www.4dayjob.com/) - 4-day work week and remote job board with 1,000+ listings across 10 categories
 
 ## Quantum Computing

--- a/README.md
+++ b/README.md
@@ -197,7 +197,6 @@ A curated list of awesome niche job boards.
 
 ### Latin America
 
-* [hiring.lat](https://hiring.lat/jobs) - Fully remote jobs for Latin American talent.
 * [Findjobit](https://findjobit.com/jobs)
 
 ### United Kingdom

--- a/README.md
+++ b/README.md
@@ -23,9 +23,8 @@ A curated list of awesome niche job boards.
 ## Artificial Intelligence (AI)
 
 * [AI Jobs](https://www.moaijobs.com/) - AI Jobs in ML, Data Science, Engineering, and Research
-* [AI Jobs](https://aijobs.app) – Jobs in Artificial Intelligence (AI)
 * [AI/ML Jobs](https://www.aimljobs.fyi) - Jobs at Top AI Companies and Startups, Updated Daily!
-* [AI Jobster](https://aijobster.work/) - Jobs from leading AI companies, across all group.
+* [AI Jobster](https://www.aijobster.work/) - Jobs from leading AI companies, across all group.
 * [ExploreJobs.ai](https://explorejobs.ai) - Find engineering, product, and research roles at the top AI startups.
 * [AI Dev Jobs](https://aidevboard.com) - 7,400+ AI/ML jobs from 417 companies with a free REST API and MCP server for AI agents
 * [Agentic Engineering Jobs](https://agentic-engineering-jobs.com) - Job board for engineers building agentic systems (RAG, AI agents, LLM-powered products, agent orchestration). Free to post, free to browse.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ A curated list of awesome niche job boards.
 * [Data Science Jobs Canada](https://www.datasciencejobscanada.com/) - Jobs in Data Science, Data Engineering, Data Analysis, AI, and Machine Learning
 * [DataScienceJobs](https://datasciencejobs.com/) - Discover the latest and greatest data science jobs
 * [AiJobsTracker](https://aijobs.18offers.com/) - Live aggregator of 400+ AI-first companies's job boards, updated daily
+* [FindADataJob](https://findadatajob.com/) - Global job board focused on data analyst roles.
 
 ## Blockchain
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ A curated list of awesome niche job boards.
 * [ExploreJobs.ai](https://explorejobs.ai) - Find engineering, product, and research roles at the top AI startups.
 * [AI Dev Jobs](https://aidevboard.com) - 7,400+ AI/ML jobs from 417 companies with a free REST API and MCP server for AI agents
 * [Agentic Engineering Jobs](https://agentic-engineering-jobs.com) - Job board for engineers building agentic systems (RAG, AI agents, LLM-powered products, agent orchestration). Free to post, free to browse.
+* [caio.pro](https://caio.pro) - C-level AI leadership jobs (Chief AI Officer, VP of AI, Head of AI/ML, Chief Data Officer), every listing AI-verified and enriched.
 
 ## Big Data
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ A curated list of awesome niche job boards.
 * [Woody3](https://www.woodyjobs.com) - Find your dream non-tech job in Web3
 * [Jobs In Blockchain](https://jobsinblockchain.com) - Discover latest Blockchain, Web3, Smart Contracts, Defi, NFT, Cryptocurrency related jobs
 * [GMI Jobs](https://gmijobs.com) - Crypto-native job board for Web3 professionals — curated roles from 200+ blockchain companies with AI-powered job enrichment.
+* [PredictionJobs](https://predictionjobs.co/) - Job board for the prediction market industry, roles from Polymarket, Kalshi, quant trading firms and more.
 
 ## Design
 

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ A curated list of awesome niche job boards.
 * [Dynamite Jobs](https://dynamitejobs.com/) - Jobs from remote-first companies
 * [Devremote](https://devremote.io/) - Remote developer jobs at remote first companies
 * [RemoteFR](https://remotefr.com/) - Full Remote jobs for French people
-* [4DayJob](https://4dayjob.com/) - 4-day work week and remote job board with 1,500+ flexible opportunities
+* [4DayJob](https://www.4dayjob.com/) - 4-day work week and remote job board with 1,000+ listings across 10 categories
 
 ## Quantum Computing
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ A curated list of awesome niche job boards.
 * [Woody3](https://www.woodyjobs.com) - Find your dream non-tech job in Web3
 * [Jobs In Blockchain](https://jobsinblockchain.com) - Discover latest Blockchain, Web3, Smart Contracts, Defi, NFT, Cryptocurrency related jobs
 * [GMI Jobs](https://gmijobs.com) - Crypto-native job board for Web3 professionals — curated roles from 200+ blockchain companies with AI-powered job enrichment.
+* [ChainJobs](https://chainjobs.io/) - Crypto, web3 and blockchain jobs aggregated daily from companies' official careers pages, with every listing linking to the employer's own application page
 
 ## Design
 


### PR DESCRIPTION
## What is SideQuest Board?

A freelance gig aggregator that collects opportunities from public communities (Reddit, Discord, forums) into one clean, curated feed — for developers, designers, writers, and other freelancers. No commission, no spam.

- **URL:** https://www.sidequestboard.app
- **Category:** General (freelance gigs)

## Checklist
- [x] Entry added in section-appropriate position, following existing format
- [x] The site is a working, publicly accessible freelance/job board
- [x] Not a duplicate of an existing entry